### PR TITLE
Eliminate HCL2 Warnings

### DIFF
--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -24,12 +24,12 @@
 
 # data.template_file.lambda_iam_policy.rendered
 data "template_file" "lambda_iam_policy" {
-  template = "${file("${path.module}/iam/policies/lambda.json")}"
+  template = file("${path.module}/iam/policies/lambda.json")
 
   vars = {
-    cognito_user_pool_arn = "${var.cognito_user_pool_arn}"
-    dynamodb_table_arn    = "${aws_dynamodb_table._.arn}"
-    sns_topic_arn         = "${aws_sns_topic._.arn}"
+    cognito_user_pool_arn = var.cognito_user_pool_arn
+    dynamodb_table_arn    = aws_dynamodb_table._.arn
+    sns_topic_arn         = aws_sns_topic._.arn
   }
 }
 
@@ -41,24 +41,22 @@ data "template_file" "lambda_iam_policy" {
 resource "aws_iam_role" "lambda" {
   name = "${var.namespace}-api-lambda"
 
-  assume_role_policy = "${
-    file("${path.module}/iam/policies/assume-role/lambda.json")
-  }"
+  assume_role_policy = file("${path.module}/iam/policies/assume-role/lambda.json")
 }
 
 # aws_iam_policy.lambda
 resource "aws_iam_policy" "lambda" {
   name = "${var.namespace}-api-lambda"
 
-  policy = "${data.template_file.lambda_iam_policy.rendered}"
+  policy = data.template_file.lambda_iam_policy.rendered
 }
 
 # aws_iam_policy_attachment.lambda
 resource "aws_iam_policy_attachment" "lambda" {
   name = "${var.namespace}-api-lambda"
 
-  policy_arn = "${aws_iam_policy.lambda.arn}"
-  roles      = ["${aws_iam_role.lambda.name}"]
+  policy_arn = aws_iam_policy.lambda.arn
+  roles      = [aws_iam_role.lambda.name]
 }
 
 # -----------------------------------------------------------------------------
@@ -99,33 +97,31 @@ resource "aws_sns_topic" "_" {
 
 # aws_api_gateway_rest_api._
 resource "aws_api_gateway_rest_api" "_" {
-  name = "${var.namespace}"
+  name = var.namespace
 }
 
 # aws_api_gateway_resource._
 resource "aws_api_gateway_resource" "_" {
-  rest_api_id = "${aws_api_gateway_rest_api._.id}"
-  parent_id   = "${aws_api_gateway_rest_api._.root_resource_id}"
+  rest_api_id = aws_api_gateway_rest_api._.id
+  parent_id   = aws_api_gateway_rest_api._.root_resource_id
   path_part   = "identity"
 }
 
 # aws_api_gateway_stage._
 resource "aws_api_gateway_stage" "_" {
-  stage_name    = "${var.api_stage}"
-  rest_api_id   = "${aws_api_gateway_rest_api._.id}"
-  deployment_id = "${aws_api_gateway_deployment._.id}"
+  stage_name    = var.api_stage
+  rest_api_id   = aws_api_gateway_rest_api._.id
+  deployment_id = aws_api_gateway_deployment._.id
 }
 
 # aws_api_gateway_deployment._
 resource "aws_api_gateway_deployment" "_" {
-  rest_api_id = "${aws_api_gateway_rest_api._.id}"
+  rest_api_id = aws_api_gateway_rest_api._.id
   stage_name  = "intermediate"
 
   # Hack: force deployment on source code hash change
   variables = {
-    "source_code_hash" = "${
-      sha256(filebase64("${path.module}/lambda/dist.zip"))
-    }"
+    "source_code_hash" = sha256(filebase64("${path.module}/lambda/dist.zip"))
   }
 
   lifecycle {
@@ -133,10 +129,10 @@ resource "aws_api_gateway_deployment" "_" {
   }
 
   depends_on = [
-    "module.authenticate",
-    "module.leave",
-    "module.register",
-    "module.reset",
+    module.authenticate,
+    module.leave,
+    module.register,
+    module.reset,
   ]
 }
 
@@ -148,21 +144,21 @@ resource "aws_api_gateway_deployment" "_" {
 module "authenticate" {
   source = "./modules/authenticate"
 
-  namespace = "${var.namespace}"
-  region    = "${var.region}"
+  namespace = var.namespace
+  region    = var.region
 
-  api_id          = "${aws_api_gateway_rest_api._.id}"
-  api_resource_id = "${aws_api_gateway_resource._.id}"
-  api_base_path   = "${aws_api_gateway_resource._.path_part}"
+  api_id          = aws_api_gateway_rest_api._.id
+  api_resource_id = aws_api_gateway_resource._.id
+  api_base_path   = aws_api_gateway_resource._.path_part
 
-  cognito_user_pool_id           = "${var.cognito_user_pool_id}"
-  cognito_user_pool_client_id    = "${var.cognito_user_pool_client_id}"
-  cognito_identity_pool_provider = "${var.cognito_identity_pool_provider}"
+  cognito_user_pool_id           = var.cognito_user_pool_id
+  cognito_user_pool_client_id    = var.cognito_user_pool_client_id
+  cognito_identity_pool_provider = var.cognito_identity_pool_provider
 
-  dynamodb_table = "${aws_dynamodb_table._.name}"
-  sns_topic_arn  = "${aws_sns_topic._.arn}"
+  dynamodb_table = aws_dynamodb_table._.name
+  sns_topic_arn  = aws_sns_topic._.arn
 
-  lambda_role_arn = "${aws_iam_role.lambda.arn}"
+  lambda_role_arn = aws_iam_role.lambda.arn
   lambda_filename = "${path.module}/lambda/dist.zip"
 }
 
@@ -170,16 +166,16 @@ module "authenticate" {
 module "leave" {
   source = "./modules/leave"
 
-  namespace = "${var.namespace}"
-  region    = "${var.region}"
+  namespace = var.namespace
+  region    = var.region
 
-  api_id          = "${aws_api_gateway_rest_api._.id}"
-  api_resource_id = "${aws_api_gateway_resource._.id}"
-  api_base_path   = "${aws_api_gateway_resource._.path_part}"
+  api_id          = aws_api_gateway_rest_api._.id
+  api_resource_id = aws_api_gateway_resource._.id
+  api_base_path   = aws_api_gateway_resource._.path_part
 
-  cognito_identity_pool_provider = "${var.cognito_identity_pool_provider}"
+  cognito_identity_pool_provider = var.cognito_identity_pool_provider
 
-  lambda_role_arn = "${aws_iam_role.lambda.arn}"
+  lambda_role_arn = aws_iam_role.lambda.arn
   lambda_filename = "${path.module}/lambda/dist.zip"
 }
 
@@ -187,19 +183,19 @@ module "leave" {
 module "register" {
   source = "./modules/register"
 
-  namespace = "${var.namespace}"
-  region    = "${var.region}"
+  namespace = var.namespace
+  region    = var.region
 
-  api_id          = "${aws_api_gateway_rest_api._.id}"
-  api_resource_id = "${aws_api_gateway_resource._.id}"
+  api_id          = aws_api_gateway_rest_api._.id
+  api_resource_id = aws_api_gateway_resource._.id
 
-  cognito_user_pool_id        = "${var.cognito_user_pool_id}"
-  cognito_user_pool_client_id = "${var.cognito_user_pool_client_id}"
+  cognito_user_pool_id        = var.cognito_user_pool_id
+  cognito_user_pool_client_id = var.cognito_user_pool_client_id
 
-  dynamodb_table = "${aws_dynamodb_table._.name}"
-  sns_topic_arn  = "${aws_sns_topic._.arn}"
+  dynamodb_table = aws_dynamodb_table._.name
+  sns_topic_arn  = aws_sns_topic._.arn
 
-  lambda_role_arn = "${aws_iam_role.lambda.arn}"
+  lambda_role_arn = aws_iam_role.lambda.arn
   lambda_filename = "${path.module}/lambda/dist.zip"
 }
 
@@ -207,18 +203,18 @@ module "register" {
 module "reset" {
   source = "./modules/reset"
 
-  namespace = "${var.namespace}"
-  region    = "${var.region}"
+  namespace = var.namespace
+  region    = var.region
 
-  api_id          = "${aws_api_gateway_rest_api._.id}"
-  api_resource_id = "${aws_api_gateway_resource._.id}"
+  api_id          = aws_api_gateway_rest_api._.id
+  api_resource_id = aws_api_gateway_resource._.id
 
-  cognito_user_pool_id        = "${var.cognito_user_pool_id}"
-  cognito_user_pool_client_id = "${var.cognito_user_pool_client_id}"
+  cognito_user_pool_id        = var.cognito_user_pool_id
+  cognito_user_pool_client_id = var.cognito_user_pool_client_id
 
-  dynamodb_table = "${aws_dynamodb_table._.name}"
-  sns_topic_arn  = "${aws_sns_topic._.arn}"
+  dynamodb_table = aws_dynamodb_table._.name
+  sns_topic_arn  = aws_sns_topic._.arn
 
-  lambda_role_arn = "${aws_iam_role.lambda.arn}"
+  lambda_role_arn = aws_iam_role.lambda.arn
   lambda_filename = "${path.module}/lambda/dist.zip"
 }

--- a/modules/api/modules/authenticate/main.tf
+++ b/modules/api/modules/authenticate/main.tf
@@ -74,7 +74,7 @@ resource "aws_lambda_function" "_" {
   timeout       = 30
   memory_size   = 512
 
-  source_code_hash = base64sha256(filebase64("${var.lambda_filename}"))
+  source_code_hash = base64sha256(filebase64(var.lambda_filename))
 
   environment {
     variables = {

--- a/modules/api/modules/authenticate/main.tf
+++ b/modules/api/modules/authenticate/main.tf
@@ -31,24 +31,24 @@ data "aws_caller_identity" "_" {}
 
 # aws_api_gateway_resource._
 resource "aws_api_gateway_resource" "_" {
-  rest_api_id = "${var.api_id}"
-  parent_id   = "${var.api_resource_id}"
+  rest_api_id = var.api_id
+  parent_id   = var.api_resource_id
   path_part   = "authenticate"
 }
 
 # aws_api_gateway_method._
 resource "aws_api_gateway_method" "_" {
-  rest_api_id   = "${var.api_id}"
-  resource_id   = "${aws_api_gateway_resource._.id}"
+  rest_api_id   = var.api_id
+  resource_id   = aws_api_gateway_resource._.id
   http_method   = "POST"
   authorization = "NONE"
 }
 
 # aws_api_gateway_integration._
 resource "aws_api_gateway_integration" "_" {
-  rest_api_id = "${var.api_id}"
-  resource_id = "${aws_api_gateway_resource._.id}"
-  http_method = "${aws_api_gateway_method._.http_method}"
+  rest_api_id = var.api_id
+  resource_id = aws_api_gateway_resource._.id
+  http_method = aws_api_gateway_method._.http_method
 
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
@@ -67,25 +67,23 @@ resource "aws_api_gateway_integration" "_" {
 # aws_lambda_function._
 resource "aws_lambda_function" "_" {
   function_name = "${var.namespace}-api-authenticate"
-  role          = "${var.lambda_role_arn}"
+  role          = var.lambda_role_arn
   runtime       = "nodejs10.x"
-  filename      = "${var.lambda_filename}"
+  filename      = var.lambda_filename
   handler       = "handlers/authenticate/index.post"
   timeout       = 30
   memory_size   = 512
 
-  source_code_hash = "${
-    base64sha256(filebase64("${var.lambda_filename}"))
-  }"
+  source_code_hash = base64sha256(filebase64("${var.lambda_filename}"))
 
   environment {
     variables = {
-      API_BASE_PATH                  = "${var.api_base_path}"
-      COGNITO_USER_POOL_ID           = "${var.cognito_user_pool_id}"
-      COGNITO_USER_POOL_CLIENT_ID    = "${var.cognito_user_pool_client_id}"
-      COGNITO_IDENTITY_POOL_PROVIDER = "${var.cognito_identity_pool_provider}"
-      DYNAMODB_TABLE                 = "${var.dynamodb_table}"
-      SNS_TOPIC_ARN                  = "${var.sns_topic_arn}"
+      API_BASE_PATH                  = var.api_base_path
+      COGNITO_USER_POOL_ID           = var.cognito_user_pool_id
+      COGNITO_USER_POOL_CLIENT_ID    = var.cognito_user_pool_client_id
+      COGNITO_IDENTITY_POOL_PROVIDER = var.cognito_identity_pool_provider
+      DYNAMODB_TABLE                 = var.dynamodb_table
+      SNS_TOPIC_ARN                  = var.sns_topic_arn
     }
   }
 }
@@ -94,7 +92,7 @@ resource "aws_lambda_function" "_" {
 resource "aws_lambda_permission" "_" {
   action        = "lambda:InvokeFunction"
   principal     = "apigateway.amazonaws.com"
-  function_name = "${aws_lambda_function._.arn}"
+  function_name = aws_lambda_function._.arn
 
   source_arn = "arn:aws:execute-api:${
     var.region

--- a/modules/api/modules/leave/main.tf
+++ b/modules/api/modules/leave/main.tf
@@ -31,24 +31,24 @@ data "aws_caller_identity" "_" {}
 
 # aws_api_gateway_resource._
 resource "aws_api_gateway_resource" "_" {
-  rest_api_id = "${var.api_id}"
-  parent_id   = "${var.api_resource_id}"
+  rest_api_id = var.api_id
+  parent_id   = var.api_resource_id
   path_part   = "leave"
 }
 
 # aws_api_gateway_method._
 resource "aws_api_gateway_method" "_" {
-  rest_api_id   = "${var.api_id}"
-  resource_id   = "${aws_api_gateway_resource._.id}"
+  rest_api_id   = var.api_id
+  resource_id   = aws_api_gateway_resource._.id
   http_method   = "POST"
   authorization = "NONE"
 }
 
 # aws_api_gateway_integration._
 resource "aws_api_gateway_integration" "_" {
-  rest_api_id = "${var.api_id}"
-  resource_id = "${aws_api_gateway_resource._.id}"
-  http_method = "${aws_api_gateway_method._.http_method}"
+  rest_api_id = var.api_id
+  resource_id = aws_api_gateway_resource._.id
+  http_method = aws_api_gateway_method._.http_method
 
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
@@ -67,21 +67,19 @@ resource "aws_api_gateway_integration" "_" {
 # aws_lambda_function._
 resource "aws_lambda_function" "_" {
   function_name = "${var.namespace}-api-leave"
-  role          = "${var.lambda_role_arn}"
+  role          = var.lambda_role_arn
   runtime       = "nodejs10.x"
-  filename      = "${var.lambda_filename}"
+  filename      = var.lambda_filename
   handler       = "handlers/leave/index.post"
   timeout       = 30
   memory_size   = 512
 
-  source_code_hash = "${
-    base64sha256(filebase64("${var.lambda_filename}"))
-  }"
+  source_code_hash = base64sha256(filebase64(var.lambda_filename))
 
   environment {
     variables = {
-      API_BASE_PATH                  = "${var.api_base_path}"
-      COGNITO_IDENTITY_POOL_PROVIDER = "${var.cognito_identity_pool_provider}"
+      API_BASE_PATH                  = var.api_base_path
+      COGNITO_IDENTITY_POOL_PROVIDER = var.cognito_identity_pool_provider
     }
   }
 }
@@ -90,7 +88,7 @@ resource "aws_lambda_function" "_" {
 resource "aws_lambda_permission" "_" {
   action        = "lambda:InvokeFunction"
   principal     = "apigateway.amazonaws.com"
-  function_name = "${aws_lambda_function._.arn}"
+  function_name = aws_lambda_function._.arn
 
   source_arn = "arn:aws:execute-api:${
     var.region

--- a/modules/api/modules/register/main.tf
+++ b/modules/api/modules/register/main.tf
@@ -31,24 +31,24 @@ data "aws_caller_identity" "_" {}
 
 # aws_api_gateway_resource._
 resource "aws_api_gateway_resource" "_" {
-  rest_api_id = "${var.api_id}"
-  parent_id   = "${var.api_resource_id}"
+  rest_api_id = var.api_id
+  parent_id   = var.api_resource_id
   path_part   = "register"
 }
 
 # aws_api_gateway_method._
 resource "aws_api_gateway_method" "_" {
-  rest_api_id   = "${var.api_id}"
-  resource_id   = "${aws_api_gateway_resource._.id}"
+  rest_api_id   = var.api_id
+  resource_id   = aws_api_gateway_resource._.id
   http_method   = "POST"
   authorization = "NONE"
 }
 
 # aws_api_gateway_integration._
 resource "aws_api_gateway_integration" "_" {
-  rest_api_id = "${var.api_id}"
-  resource_id = "${aws_api_gateway_resource._.id}"
-  http_method = "${aws_api_gateway_method._.http_method}"
+  rest_api_id = var.api_id
+  resource_id = aws_api_gateway_resource._.id
+  http_method = aws_api_gateway_method._.http_method
 
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
@@ -66,24 +66,24 @@ resource "aws_api_gateway_integration" "_" {
 
 # aws_api_gateway_resource.verify
 resource "aws_api_gateway_resource" "verify" {
-  rest_api_id = "${var.api_id}"
-  parent_id   = "${aws_api_gateway_resource._.id}"
+  rest_api_id = var.api_id
+  parent_id   = aws_api_gateway_resource._.id
   path_part   = "{code}"
 }
 
 # aws_api_gateway_method.verify
 resource "aws_api_gateway_method" "verify" {
-  rest_api_id   = "${var.api_id}"
-  resource_id   = "${aws_api_gateway_resource.verify.id}"
+  rest_api_id   = var.api_id
+  resource_id   = aws_api_gateway_resource.verify.id
   http_method   = "POST"
   authorization = "NONE"
 }
 
 # aws_api_gateway_integration.verify
 resource "aws_api_gateway_integration" "verify" {
-  rest_api_id = "${var.api_id}"
-  resource_id = "${aws_api_gateway_resource.verify.id}"
-  http_method = "${aws_api_gateway_method.verify.http_method}"
+  rest_api_id = var.api_id
+  resource_id = aws_api_gateway_resource.verify.id
+  http_method = aws_api_gateway_method.verify.http_method
 
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
@@ -102,23 +102,21 @@ resource "aws_api_gateway_integration" "verify" {
 # aws_lambda_function._
 resource "aws_lambda_function" "_" {
   function_name = "${var.namespace}-api-register"
-  role          = "${var.lambda_role_arn}"
+  role          = var.lambda_role_arn
   runtime       = "nodejs10.x"
-  filename      = "${var.lambda_filename}"
+  filename      = var.lambda_filename
   handler       = "handlers/register/index.post"
   timeout       = 30
   memory_size   = 512
 
-  source_code_hash = "${
-    base64sha256(filebase64("${var.lambda_filename}"))
-  }"
+  source_code_hash = base64sha256(filebase64(var.lambda_filename))
 
   environment {
     variables = {
-      COGNITO_USER_POOL_ID        = "${var.cognito_user_pool_id}"
-      COGNITO_USER_POOL_CLIENT_ID = "${var.cognito_user_pool_client_id}"
-      DYNAMODB_TABLE              = "${var.dynamodb_table}"
-      SNS_TOPIC_ARN               = "${var.sns_topic_arn}"
+      COGNITO_USER_POOL_ID        = var.cognito_user_pool_id
+      COGNITO_USER_POOL_CLIENT_ID = var.cognito_user_pool_client_id
+      DYNAMODB_TABLE              = var.dynamodb_table
+      SNS_TOPIC_ARN               = var.sns_topic_arn
     }
   }
 }
@@ -127,7 +125,7 @@ resource "aws_lambda_function" "_" {
 resource "aws_lambda_permission" "_" {
   principal     = "apigateway.amazonaws.com"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function._.arn}"
+  function_name = aws_lambda_function._.arn
 
   source_arn = "arn:aws:execute-api:${
     var.region
@@ -147,23 +145,21 @@ resource "aws_lambda_permission" "_" {
 # aws_lambda_function.verify
 resource "aws_lambda_function" "verify" {
   function_name = "${var.namespace}-api-register-verify"
-  role          = "${var.lambda_role_arn}"
+  role          = var.lambda_role_arn
   runtime       = "nodejs10.x"
-  filename      = "${var.lambda_filename}"
+  filename      = var.lambda_filename
   handler       = "handlers/register/verify.post"
   timeout       = 30
   memory_size   = 512
 
-  source_code_hash = "${
-    base64sha256(filebase64("${var.lambda_filename}"))
-  }"
+  source_code_hash = base64sha256(filebase64(var.lambda_filename))
 
   environment {
     variables = {
-      COGNITO_USER_POOL_ID        = "${var.cognito_user_pool_id}"
-      COGNITO_USER_POOL_CLIENT_ID = "${var.cognito_user_pool_client_id}"
-      DYNAMODB_TABLE              = "${var.dynamodb_table}"
-      SNS_TOPIC_ARN               = "${var.sns_topic_arn}"
+      COGNITO_USER_POOL_ID        = var.cognito_user_pool_id
+      COGNITO_USER_POOL_CLIENT_ID = var.cognito_user_pool_client_id
+      DYNAMODB_TABLE              = var.dynamodb_table
+      SNS_TOPIC_ARN               = var.sns_topic_arn
     }
   }
 }
@@ -172,7 +168,7 @@ resource "aws_lambda_function" "verify" {
 resource "aws_lambda_permission" "verify" {
   principal     = "apigateway.amazonaws.com"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.verify.arn}"
+  function_name = aws_lambda_function.verify.arn
 
   source_arn = "arn:aws:execute-api:${
     var.region

--- a/modules/api/modules/reset/main.tf
+++ b/modules/api/modules/reset/main.tf
@@ -31,24 +31,24 @@ data "aws_caller_identity" "_" {}
 
 # aws_api_gateway_resource._
 resource "aws_api_gateway_resource" "_" {
-  rest_api_id = "${var.api_id}"
-  parent_id   = "${var.api_resource_id}"
+  rest_api_id = var.api_id
+  parent_id   = var.api_resource_id
   path_part   = "reset"
 }
 
 # aws_api_gateway_method._
 resource "aws_api_gateway_method" "_" {
-  rest_api_id   = "${var.api_id}"
-  resource_id   = "${aws_api_gateway_resource._.id}"
+  rest_api_id   = var.api_id
+  resource_id   = aws_api_gateway_resource._.id
   http_method   = "POST"
   authorization = "NONE"
 }
 
 # aws_api_gateway_integration._
 resource "aws_api_gateway_integration" "_" {
-  rest_api_id = "${var.api_id}"
-  resource_id = "${aws_api_gateway_resource._.id}"
-  http_method = "${aws_api_gateway_method._.http_method}"
+  rest_api_id = var.api_id
+  resource_id = aws_api_gateway_resource._.id
+  http_method = aws_api_gateway_method._.http_method
 
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
@@ -66,24 +66,24 @@ resource "aws_api_gateway_integration" "_" {
 
 # aws_api_gateway_resource.verify
 resource "aws_api_gateway_resource" "verify" {
-  rest_api_id = "${var.api_id}"
-  parent_id   = "${aws_api_gateway_resource._.id}"
+  rest_api_id = var.api_id
+  parent_id   = aws_api_gateway_resource._.id
   path_part   = "{code}"
 }
 
 # aws_api_gateway_method.verify
 resource "aws_api_gateway_method" "verify" {
-  rest_api_id   = "${var.api_id}"
-  resource_id   = "${aws_api_gateway_resource.verify.id}"
+  rest_api_id   = var.api_id
+  resource_id   = aws_api_gateway_resource.verify.id
   http_method   = "POST"
   authorization = "NONE"
 }
 
 # aws_api_gateway_integration.verify
 resource "aws_api_gateway_integration" "verify" {
-  rest_api_id = "${var.api_id}"
-  resource_id = "${aws_api_gateway_resource.verify.id}"
-  http_method = "${aws_api_gateway_method.verify.http_method}"
+  rest_api_id = var.api_id
+  resource_id = aws_api_gateway_resource.verify.id
+  http_method = aws_api_gateway_method.verify.http_method
 
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
@@ -102,23 +102,21 @@ resource "aws_api_gateway_integration" "verify" {
 # aws_lambda_function._
 resource "aws_lambda_function" "_" {
   function_name = "${var.namespace}-api-reset"
-  role          = "${var.lambda_role_arn}"
+  role          = var.lambda_role_arn
   runtime       = "nodejs10.x"
-  filename      = "${var.lambda_filename}"
+  filename      = var.lambda_filename
   handler       = "handlers/reset/index.post"
   timeout       = 30
   memory_size   = 512
 
-  source_code_hash = "${
-    base64sha256(filebase64("${var.lambda_filename}"))
-  }"
+  source_code_hash = base64sha256(filebase64(var.lambda_filename))
 
   environment {
     variables = {
-      COGNITO_USER_POOL_ID        = "${var.cognito_user_pool_id}"
-      COGNITO_USER_POOL_CLIENT_ID = "${var.cognito_user_pool_client_id}"
-      DYNAMODB_TABLE              = "${var.dynamodb_table}"
-      SNS_TOPIC_ARN               = "${var.sns_topic_arn}"
+      COGNITO_USER_POOL_ID        = var.cognito_user_pool_id
+      COGNITO_USER_POOL_CLIENT_ID = var.cognito_user_pool_client_id
+      DYNAMODB_TABLE              = var.dynamodb_table
+      SNS_TOPIC_ARN               = var.sns_topic_arn
     }
   }
 }
@@ -127,7 +125,7 @@ resource "aws_lambda_function" "_" {
 resource "aws_lambda_permission" "_" {
   principal     = "apigateway.amazonaws.com"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function._.arn}"
+  function_name = aws_lambda_function._.arn
 
   source_arn = "arn:aws:execute-api:${
     var.region
@@ -147,23 +145,21 @@ resource "aws_lambda_permission" "_" {
 # aws_lambda_function.verify
 resource "aws_lambda_function" "verify" {
   function_name = "${var.namespace}-api-reset-verify"
-  role          = "${var.lambda_role_arn}"
+  role          = var.lambda_role_arn
   runtime       = "nodejs10.x"
-  filename      = "${var.lambda_filename}"
+  filename      = var.lambda_filename
   handler       = "handlers/reset/verify.post"
   timeout       = 30
   memory_size   = 512
 
-  source_code_hash = "${
-    base64sha256(filebase64("${var.lambda_filename}"))
-  }"
+  source_code_hash = base64sha256(filebase64(var.lambda_filename))
 
   environment {
     variables = {
-      COGNITO_USER_POOL_ID        = "${var.cognito_user_pool_id}"
-      COGNITO_USER_POOL_CLIENT_ID = "${var.cognito_user_pool_client_id}"
-      DYNAMODB_TABLE              = "${var.dynamodb_table}"
-      SNS_TOPIC_ARN               = "${var.sns_topic_arn}"
+      COGNITO_USER_POOL_ID        = var.cognito_user_pool_id
+      COGNITO_USER_POOL_CLIENT_ID = var.cognito_user_pool_client_id
+      DYNAMODB_TABLE              = var.dynamodb_table
+      SNS_TOPIC_ARN               = var.sns_topic_arn
     }
   }
 }
@@ -172,7 +168,7 @@ resource "aws_lambda_function" "verify" {
 resource "aws_lambda_permission" "verify" {
   principal     = "apigateway.amazonaws.com"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.verify.arn}"
+  function_name = aws_lambda_function.verify.arn
 
   source_arn = "arn:aws:execute-api:${
     var.region

--- a/modules/api/outputs.tf
+++ b/modules/api/outputs.tf
@@ -24,22 +24,22 @@
 
 # output.api_id
 output "api_id" {
-  value = "${aws_api_gateway_rest_api._.id}"
+  value = aws_api_gateway_rest_api._.id
 }
 
 # output.api_stage
 output "api_stage" {
-  value = "${aws_api_gateway_stage._.stage_name}"
+  value = aws_api_gateway_stage._.stage_name
 }
 
 # output.api_invoke_url
 output "api_invoke_url" {
-  value = "${aws_api_gateway_stage._.invoke_url}"
+  value = aws_api_gateway_stage._.invoke_url
 }
 
 # output.api_base_path
 output "api_base_path" {
-  value = "${aws_api_gateway_resource._.path_part}"
+  value = aws_api_gateway_resource._.path_part
 }
 
 # -----------------------------------------------------------------------------
@@ -48,7 +48,7 @@ output "api_base_path" {
 
 # output.dynamodb_table
 output "dynamodb_table" {
-  value = "${aws_dynamodb_table._.name}"
+  value = aws_dynamodb_table._.name
 }
 
 # -----------------------------------------------------------------------------
@@ -57,5 +57,5 @@ output "dynamodb_table" {
 
 # output.sns_topic_arn
 output "sns_topic_arn" {
-  value = "${aws_sns_topic._.arn}"
+  value = aws_sns_topic._.arn
 }

--- a/modules/identity/outputs.tf
+++ b/modules/identity/outputs.tf
@@ -24,20 +24,20 @@
 
 # output.cognito_user_pool_id
 output "cognito_user_pool_id" {
-  value = "${aws_cognito_user_pool._.id}"
+  value = aws_cognito_user_pool._.id
 }
 
 # output.cognito_user_pool_arn
 output "cognito_user_pool_arn" {
-  value = "${aws_cognito_user_pool._.arn}"
+  value = aws_cognito_user_pool._.arn
 }
 
 # output.cognito_user_pool_client_id
 output "cognito_user_pool_client_id" {
-  value = "${aws_cognito_user_pool_client._.id}"
+  value = aws_cognito_user_pool_client._.id
 }
 
 # output.cognito_identity_pool_id
 output "cognito_identity_pool_id" {
-  value = "${aws_cognito_identity_pool._.id}"
+  value = aws_cognito_identity_pool._.id
 }

--- a/modules/message/main.tf
+++ b/modules/message/main.tf
@@ -24,7 +24,7 @@
 
 # local.*
 locals {
-  enabled = "${length(var.ses_sender_address) == 0 ? 0 : 1}"
+  enabled = length(var.ses_sender_address) == 0 ? 0 : 1
 }
 
 # -----------------------------------------------------------------------------
@@ -33,11 +33,11 @@ locals {
 
 # data.template_file.lambda_iam_policy.rendered
 data "template_file" "lambda_iam_policy" {
-  count    = "${local.enabled}"
-  template = "${file("${path.module}/iam/policies/lambda.json")}"
+  count    = local.enabled
+  template = file("${path.module}/iam/policies/lambda.json")
 
   vars = {
-    cognito_user_pool_arn = "${var.cognito_user_pool_arn}"
+    cognito_user_pool_arn = var.cognito_user_pool_arn
   }
 }
 
@@ -47,29 +47,27 @@ data "template_file" "lambda_iam_policy" {
 
 # aws_iam_role.lambda
 resource "aws_iam_role" "lambda" {
-  count = "${local.enabled}"
+  count = local.enabled
   name  = "${var.namespace}-message-lambda"
 
-  assume_role_policy = "${
-    file("${path.module}/iam/policies/assume-role/lambda.json")
-  }"
+  assume_role_policy = file("${path.module}/iam/policies/assume-role/lambda.json")
 }
 
 # aws_iam_policy.lambda
 resource "aws_iam_policy" "lambda" {
-  count = "${local.enabled}"
+  count = local.enabled
   name  = "${var.namespace}-message-lambda"
 
-  policy = "${data.template_file.lambda_iam_policy.0.rendered}"
+  policy = data.template_file.lambda_iam_policy[0].rendered
 }
 
 # aws_iam_policy_attachment.lambda
 resource "aws_iam_policy_attachment" "lambda" {
-  count = "${local.enabled}"
+  count = local.enabled
   name  = "${var.namespace}-message-lambda"
 
-  policy_arn = "${aws_iam_policy.lambda.0.arn}"
-  roles      = ["${aws_iam_role.lambda.0.name}"]
+  policy_arn = aws_iam_policy.lambda[0].arn
+  roles      = [aws_iam_role.lambda[0].name]
 }
 
 # -----------------------------------------------------------------------------
@@ -78,10 +76,10 @@ resource "aws_iam_policy_attachment" "lambda" {
 
 # aws_sns_topic_subscription._
 resource "aws_sns_topic_subscription" "_" {
-  count     = "${local.enabled}"
-  topic_arn = "${var.sns_topic_arn}"
+  count     = local.enabled
+  topic_arn = var.sns_topic_arn
   protocol  = "lambda"
-  endpoint  = "${aws_lambda_function._.0.arn}"
+  endpoint  = aws_lambda_function._[0].arn
 }
 
 # -----------------------------------------------------------------------------
@@ -90,33 +88,31 @@ resource "aws_sns_topic_subscription" "_" {
 
 # aws_lambda_function._
 resource "aws_lambda_function" "_" {
-  count         = "${local.enabled}"
+  count         = local.enabled
   function_name = "${var.namespace}-message"
-  role          = "${aws_iam_role.lambda.0.arn}"
+  role          = aws_iam_role.lambda[0].arn
   runtime       = "nodejs10.x"
   filename      = "${path.module}/lambda/dist.zip"
   handler       = "index.handler"
   timeout       = 10
 
-  source_code_hash = "${
-    base64sha256(filebase64("${path.module}/lambda/dist.zip"))
-  }"
+  source_code_hash = base64sha256(filebase64("${path.module}/lambda/dist.zip"))
 
   environment {
     variables = {
-      COGNITO_USER_POOL_ID           = "${var.cognito_user_pool_id}"
-      COGNITO_IDENTITY_POOL_NAME     = "${var.cognito_identity_pool_name}"
-      COGNITO_IDENTITY_POOL_PROVIDER = "${var.cognito_identity_pool_provider}"
-      SES_SENDER_ADDRESS             = "${var.ses_sender_address}"
+      COGNITO_USER_POOL_ID           = var.cognito_user_pool_id
+      COGNITO_IDENTITY_POOL_NAME     = var.cognito_identity_pool_name
+      COGNITO_IDENTITY_POOL_PROVIDER = var.cognito_identity_pool_provider
+      SES_SENDER_ADDRESS             = var.ses_sender_address
     }
   }
 }
 
 # aws_lambda_permission._
 resource "aws_lambda_permission" "_" {
-  count         = "${local.enabled}"
+  count         = local.enabled
   principal     = "sns.amazonaws.com"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function._.0.arn}"
-  source_arn    = "${var.sns_topic_arn}"
+  function_name = aws_lambda_function._[0].arn
+  source_arn    = var.sns_topic_arn
 }

--- a/modules/route/main.tf
+++ b/modules/route/main.tf
@@ -24,7 +24,7 @@
 
 # local.*
 locals {
-  enabled = "${length(var.app_domain) == 0 ? 0 : 1}"
+  enabled = length(var.app_domain) == 0 ? 0 : 1
 }
 
 # -----------------------------------------------------------------------------
@@ -33,14 +33,14 @@ locals {
 
 # aws_route53_record._
 resource "aws_route53_record" "_" {
-  count   = "${local.enabled}"
-  zone_id = "${var.app_hosted_zone_id}"
-  name    = "${var.app_domain}"
+  count   = local.enabled
+  zone_id = var.app_hosted_zone_id
+  name    = var.app_domain
   type    = "A"
 
   alias {
-    zone_id = "${var.cloudfront_distribution_hosted_zone_id}"
-    name    = "${var.cloudfront_distribution_domain_name}"
+    zone_id = var.cloudfront_distribution_hosted_zone_id
+    name    = var.cloudfront_distribution_domain_name
 
     evaluate_target_health = false
   }

--- a/modules/web/main.tf
+++ b/modules/web/main.tf
@@ -34,7 +34,7 @@ provider "aws" {
 
 # local.*
 locals {
-  enabled = "${length(var.app_domain) == 0 ? 0 : 1}"
+  enabled = length(var.app_domain) == 0 ? 0 : 1
 }
 
 # -----------------------------------------------------------------------------
@@ -43,7 +43,7 @@ locals {
 
 # data.external.dist
 data "external" "dist" {
-  count   = "${local.enabled}"
+  count   = local.enabled
   program = ["${path.module}/s3/scripts/trigger.sh"]
 
   query = {
@@ -57,15 +57,13 @@ data "external" "dist" {
 
 # data.template_file.s3_bucket_policy.rendered
 data "template_file" "s3_bucket_policy" {
-  count    = "${local.enabled}"
-  template = "${file("${path.module}/s3/bucket/policy.json")}"
+  count    = local.enabled
+  template = file("${path.module}/s3/bucket/policy.json")
 
   vars = {
-    bucket = "${var.bucket}"
+    bucket = var.bucket
 
-    cloudfront_origin_access_identity_iam_arn = "${
-      aws_cloudfront_origin_access_identity._.0.iam_arn
-    }"
+    cloudfront_origin_access_identity_iam_arn = aws_cloudfront_origin_access_identity._[0].iam_arn
   }
 }
 
@@ -73,13 +71,13 @@ data "template_file" "s3_bucket_policy" {
 
 # data.template_file.index.rendered
 data "template_file" "index" {
-  count    = "${local.enabled}"
-  template = "${file("${path.module}/app/dist/index.html")}"
+  count    = local.enabled
+  template = file("${path.module}/app/dist/index.html")
 
   vars = {
-    api_base_path              = "${var.api_base_path}"
-    app_origin                 = "${var.app_origin}"
-    cognito_identity_pool_name = "${var.cognito_identity_pool_name}"
+    api_base_path              = var.api_base_path
+    app_origin                 = var.app_origin
+    cognito_identity_pool_name = var.cognito_identity_pool_name
   }
 }
 
@@ -89,29 +87,27 @@ data "template_file" "index" {
 
 # aws_iam_role.lambda
 resource "aws_iam_role" "lambda" {
-  count = "${local.enabled}"
+  count = local.enabled
   name  = "${var.namespace}-web-lambda"
 
-  assume_role_policy = "${
-    file("${path.module}/iam/policies/assume-role/lambda.json")
-  }"
+  assume_role_policy = file("${path.module}/iam/policies/assume-role/lambda.json")
 }
 
 # aws_iam_policy.lambda
 resource "aws_iam_policy" "lambda" {
-  count = "${local.enabled}"
+  count = local.enabled
   name  = "${var.namespace}-web-lambda"
 
-  policy = "${file("${path.module}/iam/policies/lambda.json")}"
+  policy = file("${path.module}/iam/policies/lambda.json")
 }
 
 # aws_iam_policy_attachment.lambda
 resource "aws_iam_policy_attachment" "lambda" {
-  count = "${local.enabled}"
+  count = local.enabled
   name  = "${var.namespace}-web-lambda"
 
-  policy_arn = "${aws_iam_policy.lambda.0.arn}"
-  roles      = ["${aws_iam_role.lambda.0.name}"]
+  policy_arn = aws_iam_policy.lambda[0].arn
+  roles      = [aws_iam_role.lambda[0].name]
 }
 
 # -----------------------------------------------------------------------------
@@ -120,10 +116,10 @@ resource "aws_iam_policy_attachment" "lambda" {
 
 # null_resource.dist
 resource "null_resource" "dist" {
-  count = "${local.enabled}"
+  count = local.enabled
 
   triggers = {
-    md5 = "${data.external.dist.0.result["checksum"]}"
+    md5 = data.external.dist[0].result["checksum"]
   }
 
   # Sync whole directory to S3
@@ -132,7 +128,7 @@ resource "null_resource" "dist" {
 
     environment = {
       DIRECTORY = "${path.module}/app/dist"
-      BUCKET    = "${aws_s3_bucket._.0.bucket}"
+      BUCKET    = aws_s3_bucket._[0].bucket
     }
   }
 }
@@ -143,18 +139,18 @@ resource "null_resource" "dist" {
 
 # aws_s3_bucket._
 resource "aws_s3_bucket" "_" {
-  count  = "${local.enabled}"
-  bucket = "${var.bucket}"
+  count  = local.enabled
+  bucket = var.bucket
   acl    = "private"
-  policy = "${data.template_file.s3_bucket_policy.0.rendered}"
+  policy = data.template_file.s3_bucket_policy[0].rendered
 }
 
 # aws_s3_bucket_object.index
 resource "aws_s3_bucket_object" "index" {
-  count         = "${local.enabled}"
-  bucket        = "${aws_s3_bucket._.0.bucket}"
+  count         = local.enabled
+  bucket        = aws_s3_bucket._[0].bucket
   key           = "index.html"
-  content       = "${data.template_file.index.0.rendered}"
+  content       = data.template_file.index[0].rendered
   acl           = "private"
   cache_control = "public, max-age=0, must-revalidate"
   content_type  = "text/html"
@@ -166,26 +162,24 @@ resource "aws_s3_bucket_object" "index" {
 
 # aws_cloudfront_origin_access_identity._
 resource "aws_cloudfront_origin_access_identity" "_" {
-  count = "${local.enabled}"
+  count = local.enabled
 }
 
 # aws_cloudfront_distribution._
 resource "aws_cloudfront_distribution" "_" {
-  count           = "${local.enabled}"
-  aliases         = ["${var.app_domain}"]
+  count           = local.enabled
+  aliases         = [var.app_domain]
   enabled         = true
   is_ipv6_enabled = true
   price_class     = "PriceClass_All"
 
   origin {
-    domain_name = "${aws_s3_bucket._.0.bucket_domain_name}"
+    domain_name = aws_s3_bucket._[0].bucket_domain_name
 
     origin_id = "web"
 
     s3_origin_config {
-      origin_access_identity = "${
-        aws_cloudfront_origin_access_identity._.0.cloudfront_access_identity_path
-      }"
+      origin_access_identity = aws_cloudfront_origin_access_identity._[0].cloudfront_access_identity_path
     }
   }
 
@@ -233,7 +227,7 @@ resource "aws_cloudfront_distribution" "_" {
 
     lambda_function_association {
       event_type = "origin-response"
-      lambda_arn = "${aws_lambda_function._.0.qualified_arn}"
+      lambda_arn = aws_lambda_function._[0].qualified_arn
     }
 
     viewer_protocol_policy = "redirect-to-https"
@@ -307,7 +301,7 @@ resource "aws_cloudfront_distribution" "_" {
 
     minimum_protocol_version = "TLSv1.1_2016"
     ssl_support_method       = "sni-only"
-    acm_certificate_arn      = "${var.app_certificate_arn}"
+    acm_certificate_arn      = var.app_certificate_arn
   }
 }
 
@@ -317,32 +311,30 @@ resource "aws_cloudfront_distribution" "_" {
 
 # aws_lambda_function._
 resource "aws_lambda_function" "_" {
-  count         = "${local.enabled}"
+  count         = local.enabled
   function_name = "${var.namespace}-web-security"
-  role          = "${aws_iam_role.lambda.0.arn}"
+  role          = aws_iam_role.lambda[0].arn
   runtime       = "nodejs10.x"
   filename      = "${path.module}/lambda/dist.zip"
   handler       = "index.handler"
   timeout       = 30
   memory_size   = 512
 
-  source_code_hash = "${
-    base64sha256(filebase64("${path.module}/lambda/dist.zip"))
-  }"
+  source_code_hash = base64sha256(filebase64("${path.module}/lambda/dist.zip"))
 
   # Lambda@Edge function must be located in us-east-1
-  provider = "aws.lambda"
+  provider = aws.lambda
   publish  = true
 }
 
 # aws_lambda_permission._
 resource "aws_lambda_permission" "_" {
-  count         = "${local.enabled}"
+  count         = local.enabled
   principal     = "cloudfront.amazonaws.com"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function._.0.arn}"
-  source_arn    = "${aws_cloudfront_distribution._.0.arn}"
+  function_name = aws_lambda_function._[0].arn
+  source_arn    = aws_cloudfront_distribution._[0].arn
 
   # Lambda@Edge function must be located in us-east-1
-  provider = "aws.lambda"
+  provider = aws.lambda
 }

--- a/modules/web/outputs.tf
+++ b/modules/web/outputs.tf
@@ -24,16 +24,10 @@
 
 # output.cloudfront_distribution_domain_name
 output "cloudfront_distribution_domain_name" {
-  value = "${local.enabled == 1
-    ? aws_cloudfront_distribution._.0.domain_name
-    : ""
-  }"
+  value = local.enabled == 1 ? aws_cloudfront_distribution._.0.domain_name : ""
 }
 
 # output.cloudfront_distribution_hosted_zone_id
 output "cloudfront_distribution_hosted_zone_id" {
-  value = "${local.enabled == 1
-    ? aws_cloudfront_distribution._.0.hosted_zone_id
-    : ""
-  }"
+  value = local.enabled == 1 ? aws_cloudfront_distribution._.0.hosted_zone_id : ""
 }


### PR DESCRIPTION
This change addresses all warnings which show up with terrafrom 0.12+. Below is one such warning. A total of 144 warnings were eliminated. Terraform versions prior to 0.12 will show errors for new HCL2 constructs.

Warning: Interpolation-only expressions are deprecated

  on /home/ubuntu/dev/terraform-aws-cognito-auth/modules/api/main.tf line 44, in resource "aws_iam_role" "lambda":
  44:   assume_role_policy = "${
  45:     file("${path.module}/iam/policies/assume-role/lambda.json")
  46:   }"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.

(and 136 more similar warnings elsewhere)